### PR TITLE
Adding backward compatibility for target-id syntax for AMDGPU_TARGETS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,21 @@ option(BUILD_TEST "Build rocHPCG single-node test" OFF)
 option(OPT_MEMMGMT "Build with memory management module" ON)
 option(OPT_DEFRAG "Build with memory management defragmentation" ON)
 
-# AMD targets
-set(AMDGPU_TARGETS gfx900:xnack-;gfx906:xnack-;gfx908:xnack- CACHE STRING "List of specific machine types for library to target")
+# Detect compiler support for target ID
+if(HIP_HIPCC_EXECUTABLE MATCHES ".*/hipcc$" )
+  execute_process(COMMAND ${HIP_HIPCC_EXECUTABLE} "--help"
+    OUTPUT_VARIABLE CXX_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH ".mcode\-object\-version" TARGET_ID_SUPPORT ${CXX_OUTPUT})
+endif()
+
+# Use target ID syntax if supported for AMDGPU_TARGETS
+if(TARGET_ID_SUPPORT)
+  set(AMDGPU_TARGETS gfx900:xnack-;gfx906:xnack-;gfx908:xnack- CACHE STRING "List of specific machine types for library to target")
+else()
+  set(AMDGPU_TARGETS gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
+endif()
 
 # Dependencies
 include(cmake/Dependencies.cmake)


### PR DESCRIPTION
rocHPCG cannot pick hipcc as `CMAKE_CXX_COMPILER` because we partly have to compile with MPI compiler. I replaced it with `HIP_HIPCC_EXECTUABLE` instead to check for `mcode-object-version`. Any concerns?