### PR TITLE
removed target id compatibility mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,26 +71,12 @@ option(OPT_DEFRAG "Build with memory management defragmentation" ON)
 # Dependencies
 include(cmake/Dependencies.cmake)
 
-# Set the AMDGPU_TARGETS with backward compatiblity
-# Use target ID syntax if supported for AMDGPU_TARGETS
+# Availability of rocm_check_target_ids command assures that we can also build
+# for gfx90a target
 if(COMMAND rocm_check_target_ids)
-  rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-    TARGETS "gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx908:xnack+;gfx90a:xnack-;gfx90a:xnack+")
+    set(DEFAULT_AMDGPU_TARGETS "gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx908:xnack+;gfx90a:xnack-;gfx90a:xnack+")
 else()
-  # Detect compiler support for target ID
-  # This section is deprecated. Please use rocm_check_target_ids for future use.
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-    execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--help"
-      OUTPUT_VARIABLE CXX_OUTPUT
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_STRIP_TRAILING_WHITESPACE)
-    string(REGEX MATCH ".mcode\-object\-version" TARGET_ID_SUPPORT ${CXX_OUTPUT})
-  endif()
-  if(TARGET_ID_SUPPORT)
-    set(DEFAULT_AMDGPU_TARGETS "gfx900:xnack-;gfx906:xnack-;gfx908:xnack-")
-  else()
-    set(DEFAULT_AMDGPU_TARGETS "gfx900;gfx906;gfx908")
-  endif()
+    set(DEFAULT_AMDGPU_TARGETS "gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx908:xnack+")
 endif()
 set(AMDGPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
 
@@ -99,7 +85,7 @@ find_package(HIP REQUIRED)
 find_package(rocprim REQUIRED)
 
 # Setup version
-rocm_setup_version(VERSION 0.7.13)
+rocm_setup_version(VERSION 0.7.14)
 
 # rocHPCG source directory
 add_subdirectory(src)


### PR DESCRIPTION
Target ID check never worked. I have removed compatibility mode to enable xnack targets. Using the availablility of `rocm_check_target_ids` macro to enable/disable gfx90a support.