### PR TITLE
Run only as many CgSets as necessary

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -477,7 +477,10 @@ int main(int argc, char * argv[]) {
            total_runtime);
   }
 
-  for (int i=0; i< numberOfCgSets; ++i) {
+  // Only run as long as requested. Conversely, if card performance increases this
+  // will ensure test runs at least as long as requested.
+  while ( total_runtime > times[0] ) 
+  {
     HIPZeroVector(x); // Zero out x
     ierr = CG( A, data, b, x, optMaxIters, optTolerance, niters, normr, normr0, &times[0], true, false);
     if (ierr) HPCG_fout << "Error in call to CG: " << ierr << ".\n" << endl;


### PR DESCRIPTION
The PR adjusts how many CgSets are executed based on the requested run time.  This is helpful for systems whose performance is not consistent over time.  It prevents running 'too long' when card performance drops over time and running 'too short' when card performance improves over the course of CgSet execution.

NOTE: Possibly some code can be removed related to numberCgSets.

Examples:
This change increases the chances to produce a 'valid' (ie. >1800 second ) run on cards with inconsistent performance.
- For cards whose performance decreases over time few CgSets must be run to run a full 1800 seconds.
- For cards whose performance increases over time this change ensures the full requested time is completed and it can counted a valid run. ( ie. > 1800 seconds ) 