### PR TITLE
use ucx/1.13.1 ompi/4.1.4 with ROCm 5.3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -174,7 +174,7 @@ install_openmpi( )
 {
   if [ ! -d "./deps/ucx" ]; then
     mkdir -p deps && cd deps
-    git clone --branch v1.10.0 https://github.com/openucx/ucx.git ucx
+    git clone --branch v1.13.1 https://github.com/openucx/ucx.git ucx
     cd ucx; ./autogen.sh; ./autogen.sh #why do we have to run this twice?
     mkdir build; cd build
     ../contrib/configure-opt --prefix=${PWD}/../ --with-rocm=${with_rocm} --without-knem --without-cuda --without-java
@@ -183,7 +183,7 @@ install_openmpi( )
 
   if [ ! -d "./deps/openmpi" ]; then
     mkdir -p deps && cd deps
-    git clone --branch v4.1.0 https://github.com/open-mpi/ompi.git openmpi
+    git clone --branch v4.1.4 https://github.com/open-mpi/ompi.git openmpi
     cd openmpi; ./autogen.pl; mkdir build; cd build
     ../configure --prefix=${PWD}/../ --with-ucx=${PWD}/../../ucx --without-verbs
     make -j$(nproc); make install; cd ../../..


### PR DESCRIPTION
Update build script `install.sh` to use `ucx/1.13.1` and `ompi/4.1.4`.
Tested with `rocm/5.3.0`