### PR TITLE
MPI headers availability for HIPCC

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -49,6 +49,11 @@ if (NOT MPI_FOUND)
   endif()
 else()
   option(HPCG_MPI "Compile WITH MPI support." ON)
+  if(NOT MPI_CXX_INCLUDE_DIRS)
+    # On some system with MPI compiler wrappers, MPI_CXX_INCLUDE_DIRS is not
+    # correctly populated.
+    set(MPI_CXX_INCLUDE_DIRS ${MPI_HOME}/include)
+  endif() 
 endif()
 
 # gtest

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,11 +145,21 @@ if(GPU_AWARE_MPI)
   target_compile_definitions(rochpcg PRIVATE GPU_AWARE_MPI)
 endif()
 
+if(MPI_FOUND)
+    # The user asked for MPI support     
+    if(NOT MPI_CXX_INCLUDE_DIRS)
+        # On some system with MPI compiler wrappers, MPI_CXX_INCLUDE_DIRS is not
+        # correctly populated.
+        set(MPI_CXX_INCLUDE_DIRS ${MPI_HOME}/include)
+    endif()
+endif()
+
 # Target include directories
 target_include_directories(rochpcg
-                             PRIVATE
-                               $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-                               $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>)
+                                PRIVATE
+                                $<BUILD_INTERFACE:${MPI_CXX_INCLUDE_DIRS}>
+                                $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+                                $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>)
 
 # HIP
 target_link_libraries(rochpcg PRIVATE hip::host)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,15 +145,6 @@ if(GPU_AWARE_MPI)
   target_compile_definitions(rochpcg PRIVATE GPU_AWARE_MPI)
 endif()
 
-if(MPI_FOUND)
-    # The user asked for MPI support     
-    if(NOT MPI_CXX_INCLUDE_DIRS)
-        # On some system with MPI compiler wrappers, MPI_CXX_INCLUDE_DIRS is not
-        # correctly populated.
-        set(MPI_CXX_INCLUDE_DIRS ${MPI_HOME}/include)
-    endif()
-endif()
-
 # Target include directories
 target_include_directories(rochpcg
                                 PRIVATE


### PR DESCRIPTION
On some machines, and I'll take the example of some recent HPE-Cray environment (Frontier, Lumi and Adastra); a set of modules and wrappers needs to be used if one does not what to get his hand dirty. Under this regime, I had two issues:

- HIPCC is exposed but not supported (the underlying amdclang is) and the flags such as the one needed to introduce MPI are not automatically added. I didn't succeed in making HIPFLAGS work (https://cmake.org/cmake/help/latest/envvar/HIPFLAGS.html).
- CMake can succeed in finding MPI (MPI_FOUND is TRUE) but not populate any MPI_CXX_* variable such as MPI_CXX_INCLUDE_DIRS. This is probably due to the usage of the Cray wrappers but still, according to the CMake documentation, it should be set (
https://cmake.org/cmake/help/latest/module/FindMPI.html).

The fix resolved the issues aforementioned but I did not try it on a significant amount of system/environment!
