### PR TITLE
Fix some warnings

### DIFF
--- a/src/OutputFile.cpp
+++ b/src/OutputFile.cpp
@@ -113,7 +113,7 @@ OutputFile::generate(void) {
   time_t rawtime;
   time(&rawtime);
   tm * ptm = localtime(&rawtime);
-  char sdate[25];
+  char sdate[256];
   //use tm_mon+1 because tm_mon is 0 .. 11 instead of 1 .. 12
   sprintf (sdate,"%04d-%02d-%02d_%02d-%02d-%02d",ptm->tm_year + 1900, ptm->tm_mon+1,
         ptm->tm_mday, ptm->tm_hour, ptm->tm_min,ptm->tm_sec);

--- a/src/YAML_Doc.cpp
+++ b/src/YAML_Doc.cpp
@@ -57,7 +57,7 @@ string YAML_Doc::generateYAML() {
   tm * ptm;
   time ( &rawtime );
   ptm = localtime(&rawtime);
-  char sdate[25];
+  char sdate[256];
   //use tm_mon+1 because tm_mon is 0 .. 11 instead of 1 .. 12
   sprintf (sdate,"%04d.%02d.%02d.%02d.%02d.%02d",ptm->tm_year + 1900, ptm->tm_mon+1,
       ptm->tm_mday, ptm->tm_hour, ptm->tm_min,ptm->tm_sec);
@@ -70,7 +70,7 @@ string YAML_Doc::generateYAML() {
   filename = filename + string(sdate) + ".yaml";
   if (destinationDirectory!="" && destinationDirectory!=".") {
     string mkdir_cmd = "mkdir " + destinationDirectory;
-    system(mkdir_cmd.c_str());
+    int err = system(mkdir_cmd.c_str());
     filename = destinationDirectory + "/" + destinationFileName;
   } else
     filename = "./" + filename;


### PR DESCRIPTION
Hit some warnings with gcc 11.4. This resolves them. The warning messages were:
```
/home/nchalmer/rocHPCG/src/YAML_Doc.cpp: In member function ‘std::string YAML_Doc::generateYAML()’:
/home/nchalmer/rocHPCG/src/YAML_Doc.cpp:73:11: warning: ignoring return value of ‘int system(const char*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   73 |     system(mkdir_cmd.c_str());
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~
/home/nchalmer/rocHPCG/src/YAML_Doc.cpp:62:29: warning: ‘%02d’ directive writing between 2 and 11 bytes into a region of size between 1 and 17 [-Wformat-overflow=]
   62 |   sprintf (sdate,"%04d.%02d.%02d.%02d.%02d.%02d",ptm->tm_year + 1900, ptm->tm_mon+1,
      |                             ^~~~
In file included from /usr/include/stdio.h:894,
                 from /usr/include/c++/11/cstdio:42,
                 from /usr/include/c++/11/ext/string_conversions.h:43,
                 from /usr/include/c++/11/bits/basic_string.h:6608,
                 from /usr/include/c++/11/string:55,
                 from /usr/include/c++/11/bits/locale_classes.h:40,
                 from /usr/include/c++/11/bits/ios_base.h:41,
                 from /usr/include/c++/11/ios:42,
                 from /usr/include/c++/11/ostream:38,
                 from /usr/include/c++/11/iostream:39,
                 from /home/nchalmer/rocHPCG/src/YAML_Doc.cpp:17:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:38:34: note: ‘__builtin___sprintf_chk’ output between 20 and 72 bytes into a destination of size 25
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
/home/nchalmer/rocHPCG/src/OutputFile.cpp: In member function ‘std::string OutputFile::generate()’:
/home/nchalmer/rocHPCG/src/OutputFile.cpp:118:29: warning: ‘%02d’ directive writing between 2 and 11 bytes into a region of size between 1 and 17 [-Wformat-overflow=]
  118 |   sprintf (sdate,"%04d-%02d-%02d_%02d-%02d-%02d",ptm->tm_year + 1900, ptm->tm_mon+1,
      |                             ^~~~
In file included from /usr/include/stdio.h:894,
                 from /usr/include/c++/11/cstdio:42,
                 from /usr/include/c++/11/ext/string_conversions.h:43,
                 from /usr/include/c++/11/bits/basic_string.h:6608,
                 from /usr/include/c++/11/string:55,
                 from /usr/include/c++/11/bits/locale_classes.h:40,
                 from /usr/include/c++/11/bits/ios_base.h:41,
                 from /usr/include/c++/11/ios:42,
                 from /usr/include/c++/11/istream:38,
                 from /usr/include/c++/11/fstream:38,
                 from /home/nchalmer/rocHPCG/src/OutputFile.cpp:16:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:38:34: note: ‘__builtin___sprintf_chk’ output between 20 and 72 bytes into a destination of size 25
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
```