### PR TITLE
Fix mem leaks in non-verify runs

### DIFF
--- a/src/MGData.hpp
+++ b/src/MGData.hpp
@@ -84,6 +84,7 @@ typedef struct MGData_STRUCT MGData;
 inline void InitializeMGData(local_int_t* d_f2cOperator, local_int_t* d_c2fOperator, Vector* rc, Vector* xc, Vector* Axf, MGData & data) {
   data.numberOfPresmootherSteps = 1;
   data.numberOfPostsmootherSteps = 1;
+  data.f2cOperator = nullptr;
   data.d_f2cOperator = d_f2cOperator; // Space for injection operator
   data.d_c2fOperator = d_c2fOperator;
   data.rc = rc;
@@ -99,7 +100,7 @@ inline void InitializeMGData(local_int_t* d_f2cOperator, local_int_t* d_c2fOpera
  */
 inline void DeleteMGData(MGData & data) {
 
-  delete [] data.f2cOperator;
+  if (data.f2cOperator) delete [] data.f2cOperator;
   DeleteVector(*data.Axf);
   DeleteVector(*data.rc);
   DeleteVector(*data.xc);

--- a/src/SparseMatrix.hpp
+++ b/src/SparseMatrix.hpp
@@ -263,30 +263,33 @@ inline void ReplaceMatrixDiagonal(SparseMatrix & A, Vector & diagonal) {
  */
 inline void DeleteMatrix(SparseMatrix & A) {
 
+  if (A.matrixValues) {
 #ifndef HPCG_CONTIGUOUS_ARRAYS
-  for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
-    delete [] A.matrixValues[i];
-    delete [] A.mtxIndG[i];
-    delete [] A.mtxIndL[i];
-  }
+    for (local_int_t i = 0; i< A.localNumberOfRows; ++i) {
+      if (A.matrixValues[i]) delete [] A.matrixValues[i];
+      if (A.mtxIndG[i])      delete [] A.mtxIndG[i];
+      if (A.mtxIndL[i])      delete [] A.mtxIndL[i];
+    }
 #else
-  delete [] A.matrixValues[0];
-  delete [] A.mtxIndG[0];
-  delete [] A.mtxIndL[0];
+    if (A.matrixValues[0]) delete [] A.matrixValues[0];
+    if (A.mtxIndG[0])      delete [] A.mtxIndG[0];
+    if (A.mtxIndL[0])      delete [] A.mtxIndL[0];
 #endif
-  if (A.title)                  delete [] A.title;
-  if (A.nonzerosInRow)             delete [] A.nonzerosInRow;
-  if (A.mtxIndG) delete [] A.mtxIndG;
-  if (A.mtxIndL) delete [] A.mtxIndL;
-  if (A.matrixValues) delete [] A.matrixValues;
-  if (A.matrixDiagonal)           delete [] A.matrixDiagonal;
+  }
+
+  if (A.title)          delete [] A.title;
+  if (A.nonzerosInRow)  delete [] A.nonzerosInRow;
+  if (A.mtxIndG)        delete [] A.mtxIndG;
+  if (A.mtxIndL)        delete [] A.mtxIndL;
+  if (A.matrixValues)   delete [] A.matrixValues;
+  if (A.matrixDiagonal) delete [] A.matrixDiagonal;
 
 #ifndef HPCG_NO_MPI
-  if (A.elementsToSend)       delete [] A.elementsToSend;
-  if (A.neighbors)              delete [] A.neighbors;
-  if (A.receiveLength)            delete [] A.receiveLength;
-  if (A.sendLength)            delete [] A.sendLength;
-  if (A.sendBuffer)            delete [] A.sendBuffer;
+  if (A.elementsToSend) delete [] A.elementsToSend;
+  if (A.neighbors)      delete [] A.neighbors;
+  if (A.receiveLength)  delete [] A.receiveLength;
+  if (A.sendLength)     delete [] A.sendLength;
+  if (A.sendBuffer)     delete [] A.sendBuffer;
 
   if(A.recv_request) delete[] A.recv_request;
   if(A.send_request) delete[] A.send_request;

--- a/src/Vector.hpp
+++ b/src/Vector.hpp
@@ -58,14 +58,14 @@
 
 struct Vector_STRUCT {
   local_int_t localLength;  //!< length of local portion of the vector
-  double * values;          //!< array of values
+  double * values = nullptr;          //!< array of values
   /*!
    This is for storing optimized data structures created in OptimizeProblem and
    used inside optimized ComputeSPMV().
    */
-  void * optimizationData;
+  void * optimizationData = nullptr;
 
-  double* d_values;
+  double* d_values = nullptr;
 };
 typedef struct Vector_STRUCT Vector;
 
@@ -175,7 +175,7 @@ inline void HIPCopyVector(const Vector& v, Vector& w)
  */
 inline void DeleteVector(Vector & v) {
 
-  delete [] v.values;
+  if (v.values) delete [] v.values;
   v.localLength = 0;
   return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -565,23 +565,24 @@ int main(int argc, char * argv[]) {
   // Clean up
   if(params.verify)
   {
-    DeleteMatrix(A); // This delete will recursively delete all coarse grid data
-    DeleteCGData(data);
-    HIPDeleteCGData(data);
-    DeleteVector(x);
-    DeleteVector(b);
-    DeleteVector(xexact);
-    HIPDeleteVector(x);
-    HIPDeleteVector(b);
-    HIPDeleteVector(xexact);
-    DeleteVector(x_overlap);
-    DeleteVector(b_computed);
     delete [] testnorms_data.values;
   }
   else
   {
     printf("\n*** WARNING *** THIS IS NOT A VALID RUN ***\n");
   }
+
+  DeleteVector(x);
+  DeleteVector(b);
+  DeleteVector(xexact);
+  DeleteVector(x_overlap);
+  DeleteVector(b_computed);
+  HIPDeleteVector(x);
+  HIPDeleteVector(b);
+  HIPDeleteVector(xexact);
+  DeleteCGData(data);
+  HIPDeleteCGData(data);
+  DeleteMatrix(A); // This delete will recursively delete all coarse grid data
 
   HPCG_Finalize();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -569,7 +569,7 @@ int main(int argc, char * argv[]) {
   }
   else
   {
-    printf("\n*** WARNING *** THIS IS NOT A VALID RUN ***\n");
+    if (rank==0) printf("\n*** WARNING *** THIS IS NOT A VALID RUN ***\n");
   }
 
   DeleteVector(x);


### PR DESCRIPTION
The `hipAllocator_t` memory manager complains about leaking memory at the end of non-verify runs. This resolves the leaks. 