### PR TITLE
Move the kernels in the FOM region off the null stream

### DIFF
--- a/src/ComputeDotProduct.cpp
+++ b/src/ComputeDotProduct.cpp
@@ -182,17 +182,21 @@ int ComputeDotProduct(local_int_t n,
 
     if(x.d_values == y.d_values)
     {
-        kernel_dot1_part1<1024><<<1024, 1024>>>(n, x.d_values, tmp);
-        kernel_dot_part2<1024><<<1, 1024>>>(tmp);
+        kernel_dot1_part1<1024><<<1024, 1024, 0, stream_interior>>>(n, x.d_values, tmp);
+        kernel_dot_part2<1024><<<1, 1024, 0, stream_interior>>>(tmp);
     }
     else
     {
-        kernel_dot2_part1<256><<<256, 256>>>(n, x.d_values, y.d_values, tmp);
-        kernel_dot_part2<256><<<1, 256>>>(tmp);
+        kernel_dot2_part1<256><<<256, 256, 0, stream_interior>>>(n,
+                                                                 x.d_values,
+                                                                 y.d_values,
+                                                                 tmp);
+        kernel_dot_part2<256><<<1, 256, 0, stream_interior>>>(tmp);
     }
 
     double local_result;
-    HIP_CHECK(hipMemcpy(&local_result, tmp, sizeof(double), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpyAsync(&local_result, tmp, sizeof(double), hipMemcpyDeviceToHost, stream_interior));
+    HIP_CHECK(hipStreamSynchronize(stream_interior));
 
 #ifndef HPCG_NO_MPI
     double t0 = mytimer();

--- a/src/ComputeProlongation.cpp
+++ b/src/ComputeProlongation.cpp
@@ -74,12 +74,13 @@ int ComputeProlongation(const SparseMatrix& Af, Vector& xf)
     dim3 blocks((Af.mgData->rc->localLength - 1) / 128 + 1);
     dim3 threads(128);
 
-    kernel_prolongation<128><<<blocks, threads>>>(Af.mgData->rc->localLength,
-                                                  Af.mgData->d_f2cOperator,
-                                                  Af.mgData->xc->d_values,
-                                                  xf.d_values,
-                                                  Af.perm,
-                                                  Af.Ac->perm);
+    kernel_prolongation<128><<<blocks, threads, 0, stream_interior>>>(
+        Af.mgData->rc->localLength,
+        Af.mgData->d_f2cOperator,
+        Af.mgData->xc->d_values,
+        xf.d_values,
+        Af.perm,
+        Af.Ac->perm);
 
     return 0;
 }

--- a/src/ComputeRestriction.cpp
+++ b/src/ComputeRestriction.cpp
@@ -184,13 +184,14 @@ int ComputeRestriction(const SparseMatrix& A, const Vector& rf)
     dim3 blocks((A.mgData->rc->localLength - 1) / 128 + 1);
     dim3 threads(128);
 
-    kernel_restrict<128><<<blocks, threads>>>(A.mgData->rc->localLength,
-                                              A.mgData->d_f2cOperator,
-                                              rf.d_values,
-                                              A.mgData->Axf->d_values,
-                                              A.mgData->rc->d_values,
-                                              A.perm,
-                                              A.Ac->perm);
+    kernel_restrict<128><<<blocks, threads, 0, stream_interior>>>(
+        A.mgData->rc->localLength,
+        A.mgData->d_f2cOperator,
+        rf.d_values,
+        A.mgData->Axf->d_values,
+        A.mgData->rc->d_values,
+        A.perm,
+        A.Ac->perm);
 
     return 0;
 }
@@ -215,16 +216,20 @@ int ComputeFusedSpMVRestriction(const SparseMatrix& A, const Vector& rf, Vector&
         dim3 blocks((A.halo_rows - 1) / 128 + 1);
         dim3 threads(128);
 
-        kernel_fused_restrict_spmv_halo<128><<<blocks, threads>>>(A.halo_rows,
-                                                                  A.localNumberOfColumns,
-                                                                  A.mgData->d_c2fOperator,
-                                                                  A.ell_width,
-                                                                  A.halo_row_ind,
-                                                                  A.halo_col_ind,
-                                                                  A.halo_val,
-                                                                  xf.d_values,
-                                                                  A.mgData->rc->d_values,
-                                                                  A.Ac->perm);
+        kernel_fused_restrict_spmv_halo<128><<<blocks,
+                                               threads,
+                                               0,
+                                               stream_interior>>>(
+            A.halo_rows,
+            A.localNumberOfColumns,
+            A.mgData->d_c2fOperator,
+            A.ell_width,
+            A.halo_row_ind,
+            A.halo_col_ind,
+            A.halo_val,
+            xf.d_values,
+            A.mgData->rc->d_values,
+            A.Ac->perm);
     }
 #endif
 

--- a/src/ComputeSPMV.cpp
+++ b/src/ComputeSPMV.cpp
@@ -70,7 +70,10 @@
         dim3 blocks((A.halo_rows - 1) / blocksize + 1);          \
         dim3 threads(blocksize);                                 \
                                                                  \
-        kernel_spmv_halo<blocksize, width><<<blocks, threads>>>( \
+        kernel_spmv_halo<blocksize, width><<<blocks,             \
+                                             threads,            \
+                                             0,                  \
+                                             stream_interior>>>( \
             A.halo_rows,                                         \
             A.localNumberOfColumns,                              \
             A.halo_row_ind,                                      \
@@ -255,7 +258,10 @@ int ComputeSPMV(const SparseMatrix& A, Vector& x, Vector& y)
         dim3 blocks((A.mgData->rc->localLength - 1) / 1024 + 1);
         dim3 threads(1024);
 
-        kernel_spmv_ell_coarse<1024><<<blocks, threads>>>(
+        kernel_spmv_ell_coarse<1024><<<blocks,
+                                       threads,
+                                       0,
+                                       stream_interior>>>(
             A.mgData->rc->localLength,
             A.localNumberOfRows,
             A.localNumberOfColumns,

--- a/src/ComputeSYMGS.cpp
+++ b/src/ComputeSYMGS.cpp
@@ -56,7 +56,10 @@
         dim3 blocks((A.sizes[i] - 1) / blocksize + 1);              \
         dim3 threads(blocksize);                                    \
                                                                     \
-        kernel_symgs_sweep<blocksize, width><<<blocks,  threads>>>( \
+        kernel_symgs_sweep<blocksize, width><<<blocks,              \
+                                               threads,             \
+                                               0,                   \
+                                               stream_interior>>>(  \
             A.localNumberOfRows,                                    \
             A.localNumberOfColumns,                                 \
             A.sizes[i],                                             \
@@ -91,7 +94,10 @@
         dim3 blocks((A.halo_rows - 1) / blocksize + 1);           \
         dim3 threads(blocksize);                                  \
                                                                   \
-        kernel_symgs_halo<blocksize, width><<<blocks, threads>>>( \
+        kernel_symgs_halo<blocksize, width><<<blocks,             \
+                                              threads,            \
+                                              0,                  \
+                                              stream_interior>>>( \
             A.halo_rows,                                          \
             A.localNumberOfColumns,                               \
             A.sizes[0],                                           \
@@ -402,7 +408,10 @@ int ComputeSYMGSZeroGuess(const SparseMatrix& A, const Vector& r, Vector& x)
     assert(x.localLength == A.localNumberOfColumns);
 
     // Solve L
-    kernel_pointwise_mult<256><<<(A.sizes[0] - 1) / 256 + 1, 256>>>(
+    kernel_pointwise_mult<256><<<(A.sizes[0] - 1) / 256 + 1,
+                                 256,
+                                 0,
+                                 stream_interior>>>(
         A.sizes[0],
         r.d_values,
         A.inv_diag,
@@ -410,7 +419,10 @@ int ComputeSYMGSZeroGuess(const SparseMatrix& A, const Vector& r, Vector& x)
 
     for(local_int_t i = 1; i < A.nblocks; ++i)
     {
-        kernel_forward_sweep_0<1024><<<(A.sizes[i] - 1) / 1024 + 1, 1024>>>(
+        kernel_forward_sweep_0<1024><<<(A.sizes[i] - 1) / 1024 + 1,
+                                       1024,
+                                       0,
+                                       stream_interior>>>(
             A.localNumberOfRows,
             A.sizes[i],
             A.offsets[i],
@@ -424,7 +436,10 @@ int ComputeSYMGSZeroGuess(const SparseMatrix& A, const Vector& r, Vector& x)
     // Solve U
     for(local_int_t i = A.ublocks; i >= 0; --i)
     {
-        kernel_backward_sweep_0<1024><<<(A.sizes[i] - 1) / 1024 + 1, 1024>>>(
+        kernel_backward_sweep_0<1024><<<(A.sizes[i] - 1) / 1024 + 1,
+                                        1024,
+                                        0,
+                                        stream_interior>>>(
             A.localNumberOfRows,
             A.sizes[i],
             A.offsets[i],

--- a/src/ComputeWAXPBY.cpp
+++ b/src/ComputeWAXPBY.cpp
@@ -119,12 +119,13 @@ int ComputeWAXPBY(local_int_t n,
     dim3 blocks((n - 1) / 1024 + 1);
     dim3 threads(1024);
 
-    kernel_waxpby<1024><<<blocks, threads>>>(n,
-                                             alpha,
-                                             x.d_values,
-                                             beta,
-                                             y.d_values,
-                                             w.d_values);
+    kernel_waxpby<1024><<<blocks, threads, 0, stream_interior>>>(
+        n,
+        alpha,
+        x.d_values,
+        beta,
+        y.d_values,
+        w.d_values);
 
     return 0;
 }
@@ -202,11 +203,16 @@ int ComputeFusedWAXPBYDot(local_int_t n,
 
     double* tmp = reinterpret_cast<double*>(workspace);
 
-    kernel_fused_waxpby_dot_part1<256><<<256, 256>>>(n, alpha, x.d_values, y.d_values, tmp);
-    kernel_fused_waxpby_dot_part2<256><<<1, 256>>>(tmp);
+    kernel_fused_waxpby_dot_part1<256><<<256, 256, 0, stream_interior>>>(n,
+                                                                         alpha,
+                                                                         x.d_values,
+                                                                         y.d_values,
+                                                                         tmp);
+    kernel_fused_waxpby_dot_part2<256><<<1, 256, 0, stream_interior>>>(tmp);
 
     double local_result;
-    HIP_CHECK(hipMemcpy(&local_result, tmp, sizeof(double), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpyAsync(&local_result, tmp, sizeof(double), hipMemcpyDeviceToHost, stream_interior));
+    HIP_CHECK(hipStreamSynchronize(stream_interior));
 
 #ifndef HPCG_NO_MPI
     double t0 = mytimer();

--- a/src/Vector.hpp
+++ b/src/Vector.hpp
@@ -103,7 +103,7 @@ inline void ZeroVector(Vector & v) {
 
 inline void HIPZeroVector(Vector& v)
 {
-    HIP_CHECK(hipMemset(v.d_values, 0, sizeof(double) * v.localLength));
+    HIP_CHECK(hipMemsetAsync(v.d_values, 0, sizeof(double) * v.localLength, stream_interior));
 }
 
 /*!
@@ -162,10 +162,11 @@ inline void CopyVector(const Vector & v, Vector & w) {
 
 inline void HIPCopyVector(const Vector& v, Vector& w)
 {
-    HIP_CHECK(hipMemcpy(w.d_values,
-                        v.d_values,
-                        sizeof(double) * v.localLength,
-                        hipMemcpyDeviceToDevice));
+    HIP_CHECK(hipMemcpyAsync(w.d_values,
+                             v.d_values,
+                             sizeof(double) * v.localLength,
+                             hipMemcpyDeviceToDevice,
+                             stream_interior));
 }
 
 /*!

--- a/src/finalize.cpp
+++ b/src/finalize.cpp
@@ -61,6 +61,9 @@ HPCG_Finalize(void) {
   HIP_CHECK(hipStreamDestroy(stream_interior));
   HIP_CHECK(hipStreamDestroy(stream_halo));
 
+  // Destroy events
+  HIP_CHECK(hipEventDestroy(halo_gather));
+
   // Free workspace
   HIP_CHECK(deviceFree(workspace));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -70,6 +70,7 @@ const char* NULLDEVICE="/dev/null";
 
 hipStream_t stream_interior;
 hipStream_t stream_halo;
+hipEvent_t halo_gather;
 void* workspace;
 hipAllocator_t allocator;
 
@@ -215,6 +216,9 @@ HPCG_Init(int * argc_p, char ** *argv_p, HPCG_Params & params) {
   // Create streams
   HIP_CHECK(hipStreamCreate(&stream_interior));
   HIP_CHECK(hipStreamCreate(&stream_halo));
+
+  // Create Events
+  HIP_CHECK(hipEventCreate(&halo_gather));
 
   // Initialize memory allocator
 #ifdef HPCG_MEMMGMT

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -37,6 +37,8 @@
 // Streams
 extern hipStream_t stream_interior;
 extern hipStream_t stream_halo;
+// Events
+extern hipEvent_t halo_gather;
 // Workspace
 extern void* workspace;
 // Memory allocator


### PR DESCRIPTION
Kernels in the CG solve bounce between the `stream_interior` stream and the `NULL` stream, and for whatever reason this makes the rocprof hip-trace have strange artifacts where some kernels are shown to start where their barrier packet on the NULL stream is queued, rather than where the kernel actually starts running. 

This moves all the kernels to the `stream_interior` stream, which cleans up the rocprof trace. To enforce ordering of the halo buffer before sending via MPI, I use a hipEvent. No perf impact anywhere in this change. 