### PR TITLE
Switch from using hipcc to using Clang compiler

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -4,10 +4,10 @@
 def runCompileCommand(platform, project, jobName)
 {
     project.paths.construct_build_prefix()
-        
+
     def command
     def getDependencies = auxiliary.getLibrary('rocPRIM', platform.jenkinsLabel,'develop')
-    def compiler = jobName.contains('hipclang') ? '/opt/rocm/bin/hipcc' : '/opt/rocm/bin/hcc'
+    def compiler = '/opt/rocm/bin/amdclang++'
 
     command = """#!/usr/bin/env bash
                 set -x
@@ -33,4 +33,3 @@ def runTestCommand (platform, project)
 }
 
 return this
-


### PR DESCRIPTION
Summary of proposed changes:

- Change the default compiler from hipcc to amdclang
  - As hipcc is an increasingly thin wrapper around clang, we want to reduce complexity and switch to just use clang as the default.
- This largely does not affect rocHPCG, as users were already required to specify the desired compiler.