### PR TITLE
Deprecate AMDGPU_TARGETS variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ endif()
 if (HIP_VERSION VERSION_GREATER_EQUAL "5.7")
   set(AMDGPU_TARGETS "${AMDGPU_TARGETS};gfx941;gfx942")
 endif()
+# Don't force, as users should be able to override GPU_TARGETS at the command line if desired
+set(GPU_TARGETS "${AMDGPU_TARGETS}" CACHE STRING "GPU architectures to build for")
 
 # Setup version
 rocm_setup_version(VERSION 0.8.5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,9 @@ find_package(HIP REQUIRED)
 find_package(rocprim REQUIRED)
 
 # GPU arch targets
+if(AMDGPU_TARGETS AND NOT GPU_TARGETS)
+  message( DEPRECATION "AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS." )
+endif()
 set(AMDGPU_TARGETS "gfx900;gfx906" CACHE STRING "List of specific machine types for library to target")
 if(HIP_VERSION VERSION_GREATER_EQUAL "3.7")
   set(AMDGPU_TARGETS "${AMDGPU_TARGETS};gfx908")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,7 @@ list(APPEND CMAKE_HOST_FLAGS "-g")
 endif()
 
 # AMD targets
-foreach(target ${AMDGPU_TARGETS})
+foreach(target ${GPU_TARGETS})
   list(APPEND HIP_HIPCC_FLAGS "--offload-arch=${target}")
 endforeach()
 


### PR DESCRIPTION
Summary of proposed changes:

- Change the CMake to set the GPU_TARGETS variable from AMDGPU_TARGETS if not set by the user
- Change usages of AMDGPU_TARGETS to GPU_TARGETS