### PR TITLE
[omptarget] Fix missing include

### DIFF
--- a/omptarget/hpcg/src/OptimizeProblem.cpp
+++ b/omptarget/hpcg/src/OptimizeProblem.cpp
@@ -21,6 +21,8 @@
 #include "globals.hpp"
 #include "OptimizeProblem.hpp"
 
+#include <cstdio>
+
 #if defined(HPCG_USE_MULTICOLORING)
 void ColorSparseMatrixRows(SparseMatrix & A) {
   const local_int_t nrow = A.localNumberOfRows;


### PR DESCRIPTION
This resolves a build issue on the OpenMP target implementation.