### PR TITLE
Fix kernel_dot_part2 for smaller BLOCKSIZE

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,7 +83,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        c++17
 TabWidth:        8
 UseTab:          Never
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ project(rochpcg LANGUAGES CXX)
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE INTERNAL "Installation directory for libraries" FORCE)
 
 # Build flags
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ foreach(i ${rochpcg_hip_source})
 endforeach()
 
 # HIP flags workaround while target_compile_options does not work
-list(APPEND HIP_HIPCC_FLAGS "-std=c++14 -O3 -march=native -Wno-unused-command-line-argument -Wno-duplicate-decl-specifier -ffp-contract=fast -ffast-math -funsafe-math-optimizations")
+list(APPEND HIP_HIPCC_FLAGS "-std=c++17 -O3 -march=native -Wno-unused-command-line-argument -Wno-duplicate-decl-specifier -ffp-contract=fast -ffast-math -funsafe-math-optimizations")
 list(APPEND CMAKE_HOST_FLAGS "-O3;-march=native")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/ComputeDotProduct.cpp
+++ b/src/ComputeDotProduct.cpp
@@ -64,6 +64,9 @@ template <unsigned int BLOCKSIZE>
 __launch_bounds__(BLOCKSIZE)
 __global__ void kernel_dot1_part1(local_int_t n, const double* x, double* workspace)
 {
+    // Make sure we have a power-of-two for BLOCKSIZE
+    static_assert((BLOCKSIZE > 0) && ((BLOCKSIZE & (BLOCKSIZE-1)) == 0));
+
     local_int_t gid = blockIdx.x * BLOCKSIZE + threadIdx.x;
     local_int_t inc = gridDim.x * BLOCKSIZE;
 
@@ -102,6 +105,9 @@ __global__ void kernel_dot2_part1(local_int_t n,
                                   const double* y,
                                   double* workspace)
 {
+    // Make sure we have a power-of-two for BLOCKSIZE
+    static_assert((BLOCKSIZE > 0) && ((BLOCKSIZE & (BLOCKSIZE-1)) == 0));
+
     local_int_t gid = blockIdx.x * BLOCKSIZE + threadIdx.x;
     local_int_t inc = gridDim.x * BLOCKSIZE;
 
@@ -134,6 +140,9 @@ template <unsigned int BLOCKSIZE>
 __launch_bounds__(BLOCKSIZE)
 __global__ void kernel_dot_part2(double* workspace)
 {
+    // Make sure we have a power-of-two for BLOCKSIZE
+    static_assert((BLOCKSIZE > 0) && ((BLOCKSIZE & (BLOCKSIZE-1)) == 0));
+
     __shared__ double sdata[BLOCKSIZE];
     sdata[threadIdx.x] = workspace[threadIdx.x];
 

--- a/src/ComputeDotProduct.cpp
+++ b/src/ComputeDotProduct.cpp
@@ -138,9 +138,14 @@ __global__ void kernel_dot_part2(double* workspace)
     sdata[threadIdx.x] = workspace[threadIdx.x];
 
     __syncthreads();
-
-    if(threadIdx.x < 512) sdata[threadIdx.x] += sdata[threadIdx.x + 512]; __syncthreads();
-    if(threadIdx.x < 256) sdata[threadIdx.x] += sdata[threadIdx.x + 256]; __syncthreads();
+    if constexpr(BLOCKSIZE > 512)
+    {
+        if(threadIdx.x < 512) sdata[threadIdx.x] += sdata[threadIdx.x + 512]; __syncthreads();
+    }
+    if constexpr(BLOCKSIZE > 256)
+    {
+        if(threadIdx.x < 256) sdata[threadIdx.x] += sdata[threadIdx.x + 256]; __syncthreads();
+    }
     if(threadIdx.x < 128) sdata[threadIdx.x] += sdata[threadIdx.x + 128]; __syncthreads();
     if(threadIdx.x <  64) sdata[threadIdx.x] += sdata[threadIdx.x +  64]; __syncthreads();
     if(threadIdx.x <  32) sdata[threadIdx.x] += sdata[threadIdx.x +  32]; __syncthreads();


### PR DESCRIPTION
Builds on #86 and is the primary motivation from my end for moving to c++17, namely to be able to use `if constexpr()`. This is not the most general solution, but does fix the existing use-cases in the dot product code; I did not scour the other parts of the code for similar instances. Commit message lays out the issue in detail.

If we don't think this is enough impetus (together with rocPRIM deprecating c++14) to move to c++17 then I can cook up a different solution to this problem that only uses c++14. 

Tested the fix on the offending setup, as well as existing (functioning) setups.