### PR TITLE
ci: Remove call to junit from math ci

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -29,7 +29,6 @@ def runTestCommand (platform, project)
                   """
 
     platform.runCommand(this, command)
-    junit "${project.paths.project_build_prefix}/build/release/tests/*.xml"
 }
 
 return this


### PR DESCRIPTION
Math CI no longer uses junit