### PR TITLE
Fix OpenMP target ATTACH performance regression

### DIFF
--- a/omptarget/hpcg/src/CG.cpp
+++ b/omptarget/hpcg/src/CG.cpp
@@ -155,6 +155,9 @@ int CG(const SparseMatrix & A, CGData & data, const Vector & b, Vector & x,
   return 0;
 }
 
+// Note: we assume the matrix is already allocated on the device using something
+// such as map(to: A). This is relevant because it means that the members are
+// already present on the device and thus available for pointer attachment.
 void MapMultiGridSparseMatrix(SparseMatrix &A) {
   int totalNonZeroValues = MAP_MAX_LENGTH * A.localNumberOfRows;
 #ifdef HPCG_OPENMP_TARGET
@@ -168,8 +171,8 @@ void MapMultiGridSparseMatrix(SparseMatrix &A) {
 
 #ifndef HPCG_CONTIGUOUS_ARRAYS
 // If 1 array per row is used
-#pragma omp target enter data map(to: A.matrixValues[:A.localNumberOfRows])
-#pragma omp target enter data map(to: A.mtxIndL[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: A.matrixValues[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: A.mtxIndL[:A.localNumberOfRows])
   for (int i = 0; i < A.localNumberOfRows; ++i) {
 #pragma omp target enter data map(to: A.matrixValues[i][:A.nonzerosInRow[i]])
 #pragma omp target enter data map(to: A.mtxIndL[i][:A.nonzerosInRow[i]])
@@ -180,8 +183,8 @@ void MapMultiGridSparseMatrix(SparseMatrix &A) {
 #pragma omp target enter data map(to: A.matrixValuesSOA[:totalNonZeroValues])
 #pragma omp target enter data map(to: A.mtxIndLSOA[:totalNonZeroValues])
 #else
-#pragma omp target enter data map(to: A.matrixValues[:A.localNumberOfRows])
-#pragma omp target enter data map(to: A.mtxIndL[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: A.matrixValues[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: A.mtxIndL[:A.localNumberOfRows])
 #pragma omp target enter data map(to: A.matrixValues[0][:totalNonZeroValues])
 #pragma omp target enter data map(to: A.mtxIndL[0][:totalNonZeroValues])
   // Connect the pointers in the pointer array with the pointed positions
@@ -233,6 +236,9 @@ void MapMultiGridSparseMatrix(SparseMatrix &A) {
   }
 }
 
+// Note: we assume that the matrix itself is going to be released by the caller
+// after this method. As a result, it's not necessary to release individual
+// members here.
 void UnMapMultiGridSparseMatrix(SparseMatrix &A) {
   int totalNonZeroValues = MAP_MAX_LENGTH * A.localNumberOfRows;
   // Recursive call to make sure ALL layers are unmapped:

--- a/omptarget/hpcg/src/TestCG.cpp
+++ b/omptarget/hpcg/src/TestCG.cpp
@@ -92,12 +92,12 @@ int TestCG(SparseMatrix & A, CGData & data, Vector & b, Vector & x, TestCGData &
 
   // Map additional arrays:
 #ifdef HPCG_OPENMP_TARGET
-#pragma omp target enter data map(to: b.values[:A.localNumberOfRows])
-#pragma omp target enter data map(to: x.values[:A.localNumberOfRows])
-#pragma omp target enter data map(to: data.p.values[:A.localNumberOfColumns])
-#pragma omp target enter data map(to: data.z.values[:A.localNumberOfColumns])
-#pragma omp target enter data map(to: data.Ap.values[:A.localNumberOfRows])
-#pragma omp target enter data map(to: data.r.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: b.values) map(to: b.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: x.values) map(to: x.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: data.p.values) map(to: data.p.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: data.z.values) map(to: data.z.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: data.Ap.values) map(to: data.Ap.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: data.r.values) map(to: data.r.values[:A.localNumberOfRows])
 #endif
 
   int niters = 0;
@@ -140,12 +140,12 @@ int TestCG(SparseMatrix & A, CGData & data, Vector & b, Vector & x, TestCGData &
 
   // Clean-up device array mappings:
 #ifdef HPCG_OPENMP_TARGET
-#pragma omp target exit data map(release: b.values[:A.localNumberOfRows])
-#pragma omp target exit data map(from: x.values[:A.localNumberOfRows])
-#pragma omp target exit data map(from: data.p.values[:A.localNumberOfColumns])
-#pragma omp target exit data map(from: data.z.values[:A.localNumberOfColumns])
-#pragma omp target exit data map(from: data.Ap.values[:A.localNumberOfRows])
-#pragma omp target exit data map(from: data.r.values[:A.localNumberOfRows])
+#pragma omp target exit data map(release: b.values[:A.localNumberOfRows]) map(release: b.values)
+#pragma omp target exit data map(from: x.values[:A.localNumberOfRows]) map(release: x.values)
+#pragma omp target exit data map(from: data.p.values[:A.localNumberOfColumns]) map(release: data.p.values)
+#pragma omp target exit data map(from: data.z.values[:A.localNumberOfColumns]) map(release: data.z.values)
+#pragma omp target exit data map(from: data.Ap.values[:A.localNumberOfRows]) map(release: data.Ap.values)
+#pragma omp target exit data map(from: data.r.values[:A.localNumberOfRows]) map(release: data.r.values)
 #endif
 
   // Restore matrix diagonal and RHS

--- a/omptarget/hpcg/src/TestSymmetry.cpp
+++ b/omptarget/hpcg/src/TestSymmetry.cpp
@@ -89,9 +89,9 @@ int TestSymmetry(SparseMatrix & A, Vector & b, Vector & xexact, TestSymmetryData
 
  // Map additional arrays:
 #ifdef HPCG_OPENMP_TARGET
-#pragma omp target enter data map(to: x_ncol.values[:A.localNumberOfColumns])
-#pragma omp target enter data map(to: y_ncol.values[:A.localNumberOfColumns])
-#pragma omp target enter data map(to: z_ncol.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: x_ncol.values) map(to: x_ncol.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: y_ncol.values) map(to: y_ncol.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: z_ncol.values) map(to: z_ncol.values[:A.localNumberOfColumns])
 #endif
 
  // Next, compute x'*A*y
@@ -145,9 +145,9 @@ int TestSymmetry(SparseMatrix & A, Vector & b, Vector & xexact, TestSymmetryData
 #endif
 
 #ifdef HPCG_OPENMP_TARGET
-#pragma omp target exit data map(from: x_ncol.values[:A.localNumberOfColumns])
-#pragma omp target exit data map(from: y_ncol.values[:A.localNumberOfColumns])
-#pragma omp target exit data map(from: z_ncol.values[:A.localNumberOfColumns])
+#pragma omp target exit data map(from: x_ncol.values[:A.localNumberOfColumns]) map(release: x_ncol.values)
+#pragma omp target exit data map(from: y_ncol.values[:A.localNumberOfColumns]) map(release: y_ncol.values)
+#pragma omp target exit data map(from: z_ncol.values[:A.localNumberOfColumns]) map(release: z_ncol.values)
 #endif
 
  CopyVector(xexact, x_ncol); // Copy exact answer into overlap vector

--- a/omptarget/hpcg/src/main.cpp
+++ b/omptarget/hpcg/src/main.cpp
@@ -276,12 +276,12 @@ int main(int argc, char * argv[]) {
 
   // Map additional arrays:
 #ifdef HPCG_OPENMP_TARGET
-#pragma omp target enter data map(to: b.values[:A.localNumberOfRows])
-#pragma omp target enter data map(to: x.values[:A.localNumberOfRows])
-#pragma omp target enter data map(to: data.p.values[:A.localNumberOfColumns])
-#pragma omp target enter data map(to: data.z.values[:A.localNumberOfColumns])
-#pragma omp target enter data map(to: data.Ap.values[:A.localNumberOfRows])
-#pragma omp target enter data map(to: data.r.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: b.values) map(to: b.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: x.values) map(to: x.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: data.p.values) map(to: data.p.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: data.z.values) map(to: data.z.values[:A.localNumberOfColumns])
+#pragma omp target enter data map(alloc: data.Ap.values) map(to: data.Ap.values[:A.localNumberOfRows])
+#pragma omp target enter data map(alloc: data.r.values) map(to: data.r.values[:A.localNumberOfRows])
 #endif
 
   niters = 0;
@@ -379,12 +379,12 @@ int main(int argc, char * argv[]) {
 
   // Clean-up the rest of the arrays:
 #ifdef HPCG_OPENMP_TARGET
-#pragma omp target exit data map(release: b.values[:A.localNumberOfRows])
-#pragma omp target exit data map(from: x.values[:A.localNumberOfRows])
-#pragma omp target exit data map(release: data.p.values[:A.localNumberOfColumns])
-#pragma omp target exit data map(release: data.z.values[:A.localNumberOfColumns])
-#pragma omp target exit data map(release: data.Ap.values[:A.localNumberOfRows])
-#pragma omp target exit data map(release: data.r.values[:A.localNumberOfRows])
+#pragma omp target exit data map(release: b.values[:A.localNumberOfRows], b.values)
+#pragma omp target exit data map(from: x.values[:A.localNumberOfRows]) map(release: x.values)
+#pragma omp target exit data map(release: data.p.values[:A.localNumberOfColumns], data.p.values)
+#pragma omp target exit data map(release: data.z.values[:A.localNumberOfColumns], data.z.values)
+#pragma omp target exit data map(release: data.Ap.values[:A.localNumberOfRows], data.Ap.values)
+#pragma omp target exit data map(release: data.r.values[:A.localNumberOfRows], data.r.values)
 #endif
 
   // Compute difference between known exact solution and computed solution


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/153683, we experienced a drastic decline in runtime performance (it dropped to ~10%).
However, the linked PR is not the reason. Instead, some of the OpenMP target data environments in rocHPCG have subtle inefficiencies. A simplified example:

We have a struct "a" with a pointer member "p". We now create a device data environment using "target enter data" and map our array "p" to the device. Then, we can launch kernels as we please.
```
#pragma omp target enter data map(to: a.p[:N])
[...]
#pragma omp target teams distribute parallel for
```
However, without an additional "map(alloc: a.p)" on "target enter data", there is no pointer attachment (i.e., a mapping between a target and a host pointer) happening, because "a.p" doesn't exist in the target region. I thought that this was implicit, but it's not. As a result, every kernel launch inside the device data environment creates an implicit map of "a" to ensure that we have "a.p". And this implicit mapping of "a" is exactly what we don't want. (For performance **and** correctness reasons.)