### PR TITLE
Fix global->local nomenclature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ You can run the rocHPCG benchmark application by either using command line param
 ```
 rochpcg <nx> <ny> <nz> <runtime>
 # where
-# nx      - is the global problem size in x dimension
-# ny      - is the global problem size in y dimension
-# nz      - is the global problem size in z dimension
+# nx      - is the local (per-rank) problem size in x dimension
+# ny      - is the local (per-rank) problem size in y dimension
+# nz      - is the local (per-rank) problem size in z dimension
 # runtime - is the desired benchmarking time in seconds (> 1800s for official runs)
 ```
 


### PR DESCRIPTION
The readme talked about the "global" problem size for a parameter that determined the problem size per MPI-rank.  This has been addressed with this commit.